### PR TITLE
Remove unused image feature and filter option text

### DIFF
--- a/api/rpg.py
+++ b/api/rpg.py
@@ -1,5 +1,5 @@
 # api/rpg.py
-import os, json, base64
+import os, json
 from http.server import BaseHTTPRequestHandler
 import google.generativeai as genai
 
@@ -15,23 +15,6 @@ SYSTEM_PROMPT = (
     "請使用繁體中文，且不要暴雷未來劇情。"
 )
 
-# ---------- 產圖工具 ----------
-def generate_scene_image(prompt: str) -> str | None:
-    """
-    以 prompt 生成插畫 PNG，回傳 base64 字串；失敗回 None。
-    Flash Free Tier 每小時 60 張，避免頻繁呼叫。
-    """
-    try:
-        resp = model.generate_content(
-            prompt + "。請以插畫風格呈現，16:9 構圖，PNG。",  # 引導生成圖
-            generation_config={"mime_type": "image/png"}
-        )
-        part = resp.candidates[0].content.parts[0]
-        if part.mime_type == "image/png" and part.data:
-            return base64.b64encode(part.data).decode()
-    except Exception:
-        pass
-    return None
 
 # ---------- HTTP Handler ----------
 class handler(BaseHTTPRequestHandler):
@@ -63,15 +46,11 @@ class handler(BaseHTTPRequestHandler):
             resp = model.generate_content(messages)
             gm_reply = resp.text.strip()
 
-            # 產生插圖（可能回傳 None）
-            img_b64 = generate_scene_image(gm_reply)
-
             # 更新歷史
             history.append({"user": user_input, "gm": gm_reply})
 
             self._json(200, {
                 "reply": gm_reply,
-                "image": img_b64,
                 "history": history
             })
 

--- a/index.html
+++ b/index.html
@@ -8,38 +8,68 @@ body{font-family:system-ui;padding:0 1rem;max-width:680px;margin:auto}
 h1{display:flex;align-items:center;gap:.4rem}
 #log{white-space:pre-wrap;background:#f7f7f7;padding:1rem;
      border-radius:8px;height:55vh;overflow:auto}
-#scene{max-width:100%;border-radius:8px;margin-top:1rem;display:none}
+#options{margin-top:.5rem;display:flex;gap:.5rem;flex-wrap:wrap}
 #msg{width:100%;padding:.6rem;border-radius:6px;border:1px solid #ccc;margin-top:.8rem}
 button{margin-top:.5rem;padding:.5rem 1.2rem;border:0;border-radius:6px;background:#0070f3;color:#fff}
 </style>
 <h1>🥐 銀河龍與地城 • 文字冒險</h1>
 
 <div id="log">(故事開始！請輸入你的動作…)</div>
-<img id="scene">
+<div id="options"></div>
 
 <input id="msg" placeholder="輸入動作／例如：『我舉劍衝向機械巨龍』"/>
 <button id="send">送出</button>
+<p style="text-align:center;margin-top:1rem">遊戲設計：李詩民</p>
 
 <script>
 const log   = document.getElementById('log');
-const img   = document.getElementById('scene');
 const msgIn = document.getElementById('msg');
+const opts  = document.getElementById('options');
 const histKey="rpg_history";
 let history = JSON.parse(localStorage.getItem(histKey)||"[]");
 
+function stripOptions(text){
+  return text.split(/\n+/).filter(line=>{
+    return !line.trim().match(/^([ABC])[\.\)\s\u3001\uFF0E\uFF61]?\s*(.+)/);
+  }).join('\n');
+}
+
 // 載入舊劇情
 history.forEach(h=>{
-  log.textContent += `\n\n【你】\n${h.user}\n\n【GM】\n${h.gm}`;
+  const gmText = stripOptions(h.gm);
+  log.textContent += `\n\n【你】\n${h.user}\n\n【GM】\n${gmText}`;
 });
+if(history.length){
+  showOptions(history[history.length-1].gm);
+}
 
 function add(text, who){
   log.textContent += `\n\n【${who}】\n`+ text;
   log.scrollTop = log.scrollHeight;
 }
 
+function showOptions(text){
+  opts.innerHTML = '';
+  const lines = [];
+  text.split(/\n+/).forEach(line=>{
+    const m = line.trim().match(/^([ABC])[\.\)\s\u3001\uFF0E\uFF61]?\s*(.+)/);
+    if(m){
+      const btn = document.createElement('button');
+      btn.textContent = line.trim();
+      btn.onclick = ()=>{ msgIn.value = m[1]; send(); };
+      opts.appendChild(btn);
+    } else {
+      lines.push(line);
+    }
+  });
+  return lines.join('\n');
+}
+
 async function send(){
   if(send.cooldown) return;          // 5 秒冷卻避免爆量產圖
   send.cooldown = true; setTimeout(()=>send.cooldown=false,5000);
+
+  opts.innerHTML = '';
 
   const user = msgIn.value.trim();
   if(!user) return;
@@ -53,11 +83,8 @@ async function send(){
   const data = await res.json();
   if(data.error){ add("⚠️ "+data.error,"系統"); return;}
 
-  add(data.reply,"GM");
-  if(data.image){
-    img.src="data:image/png;base64,"+data.image;
-    img.style.display="block";
-  }
+  const gmText = showOptions(data.reply);
+  add(gmText,"GM");
   history = data.history;
   localStorage.setItem(histKey, JSON.stringify(history));
 }


### PR DESCRIPTION
## Summary
- remove image generation logic from `api/rpg.py`
- strip option lines before showing GM text and display last options on reload
- drop `<img>` tag and adjust scripts in `index.html`

## Testing
- `python hello.py`
- `python -m py_compile api/rpg.py`
